### PR TITLE
ENH: add image pull secret support

### DIFF
--- a/charts/xinference/templates/deployment-supervisor.yaml
+++ b/charts/xinference/templates/deployment-supervisor.yaml
@@ -57,10 +57,18 @@ spec:
         app: xinference-supervisor
       {{- include "charts.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.config.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.config.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - args: {{- toYaml .Values.xinferenceSupervisor.supervisor.args | nindent 8 }}
         command:
-        - xinference-supervisor
+          {{- if .Values.xinferenceSupervisor.supervisor.command }}
+          {{- toYaml .Values.xinferenceSupervisor.supervisor.command | nindent 10 }}
+          {{- else }}
+          - "xinference-supervisor"
+          {{- end }}
         env:
         - name: POD_IP
           valueFrom:

--- a/charts/xinference/templates/deployment-worker.yaml
+++ b/charts/xinference/templates/deployment-worker.yaml
@@ -18,6 +18,10 @@ spec:
         app: xinference-worker
       {{- include "charts.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.config.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.config.imagePullSecrets | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: check-supervisor
         image: {{ .Values.config.curl_image | quote }}


### PR DESCRIPTION
This PR supports:

1.  `imagePullSecret` could be specified when pulling images from authentication required repo.
2. Allow command to overwrite the default one sor supervisor.