### PR TITLE
ENH: Allow setting different image for supervisor and worker

### DIFF
--- a/charts/xinference/templates/deployment-supervisor.yaml
+++ b/charts/xinference/templates/deployment-supervisor.yaml
@@ -86,7 +86,9 @@ spec:
         - name: {{ $key }}
           value: {{ $value }}
 {{- end }}
-{{- if .Values.config.xinference_image }}
+{{- if .Values.xinferenceSupervisor.supervisor.image }}
+        image: {{ .Values.xinferenceSupervisor.supervisor.image | quote }}
+{{- else if .Values.config.xinference_image }}
         image: {{ .Values.config.xinference_image | quote }}
 {{- else }}
         image: "xprobe/xinference:{{ .Chart.AppVersion }}"

--- a/charts/xinference/templates/deployment-worker.yaml
+++ b/charts/xinference/templates/deployment-worker.yaml
@@ -49,7 +49,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-{{- if .Values.config.xinference_image }}
+{{- if .Values.xinferenceWorker.worker.image }}
+        image: {{ .Values.xinferenceWorker.worker.image | quote }}
+{{- else if .Values.config.xinference_image }}
         image: {{ .Values.config.xinference_image | quote }}
 {{- else }}
         image: "xprobe/xinference:{{ .Chart.AppVersion }}"

--- a/charts/xinference/values.yaml
+++ b/charts/xinference/values.yaml
@@ -62,6 +62,7 @@ serviceWorker:
   type: ClusterIP
 xinferenceSupervisor:
   supervisor:
+    image: ""
     args:
     - --port
     - "9997"
@@ -91,6 +92,7 @@ xinferenceWorker:
   worker:
     initContainers:
       command: [ 'sh', '-c', "until curl -v http://service-supervisor:9997/v1/address; do echo waiting for supervisor; sleep 1; done" ]
+    image: ""
     args:
     - -e
     - http://service-supervisor:9997

--- a/examples/values-distributed-case.yaml
+++ b/examples/values-distributed-case.yaml
@@ -5,6 +5,10 @@
 # To achieve this effect, the main changes were made to
 # the `config.worker_num` and `xinferenceWorker.worker.resources` parameters.
 #
+# If you want to use your GPUs just for worker nodes, change the value of xinferenceSupervisor.supervisor.image
+# and specify an image with -cpu suffix, and then update the resources block to require nvidia.com/gpu: "0".
+# Or use common config.xinference_image to specify same image for supervisor and all workers.
+#
 ###############################################################################################
 
 # common used configurations
@@ -71,6 +75,7 @@ serviceWorker:
   type: ClusterIP
 xinferenceSupervisor:
   supervisor:
+    image: ""
     args:
     - --port
     - "9997"
@@ -95,6 +100,7 @@ xinferenceWorker:
   worker:
     initContainers:
       command: [ 'sh', '-c', "until curl -v http://service-supervisor:9997/v1/address; do echo waiting for supervisor; sleep 1; done" ]
+    image: ""
     args:
     - -e
     - http://service-supervisor:9997

--- a/examples/values-local-storage.yaml
+++ b/examples/values-local-storage.yaml
@@ -74,6 +74,7 @@ serviceWorker:
   type: ClusterIP
 xinferenceSupervisor:
   supervisor:
+    image: ""
     args:
     - --port
     - "9997"
@@ -98,6 +99,7 @@ xinferenceWorker:
   worker:
     initContainers:
       command: [ 'sh', '-c', "until curl -v http://service-supervisor:9997/v1/address; do echo waiting for supervisor; sleep 1; done" ]
+    image: ""
     args:
     - -e
     - http://service-supervisor:9997


### PR DESCRIPTION
There should not be a need for supervisor to use GPU based image