### PR TITLE
FEAT: run xinference with hami vgpu in k8s

### DIFF
--- a/charts/xinference/templates/_helpers.tpl
+++ b/charts/xinference/templates/_helpers.tpl
@@ -88,3 +88,21 @@ Create the name of the service account to use
 {{- end -}}
 {{- $result -}}
 {{- end -}}
+
+
+{{- define "charts.worker.resources" -}}
+{{- if .Values.xinferenceWorker.worker.vgpu.enabled }}
+  {{- toYaml .Values.xinferenceWorker.worker.vgpu.resources }}
+{{- else }}
+  {{- toYaml .Values.xinferenceWorker.worker.resources }}
+{{- end }}
+{{- end -}}
+
+
+{{- define "charts.supervisor.resources" -}}
+{{- if .Values.xinferenceSupervisor.supervisor.vgpu.enabled }}
+  {{- toYaml .Values.xinferenceSupervisor.supervisor.vgpu.resources }}
+{{- else }}
+  {{- toYaml .Values.xinferenceSupervisor.supervisor.resources }}
+{{- end }}
+{{- end -}}

--- a/charts/xinference/templates/deployment-supervisor.yaml
+++ b/charts/xinference/templates/deployment-supervisor.yaml
@@ -98,7 +98,7 @@ spec:
 {{- end }}
         name: supervisor
         ports: {{- toYaml .Values.xinferenceSupervisor.supervisor.ports | nindent 10 }}
-        resources: {{- toYaml .Values.xinferenceSupervisor.supervisor.resources | nindent 10 }}
+        resources: {{ include "charts.supervisor.resources" . | nindent 10 }}
 {{- if .Values.config.persistence.enabled }}
         volumeMounts:
           - mountPath: {{ .Values.config.persistence.mountPath }}

--- a/charts/xinference/templates/deployment-worker.yaml
+++ b/charts/xinference/templates/deployment-worker.yaml
@@ -61,7 +61,7 @@ spec:
 {{- end }}
         name: worker
         ports: {{- toYaml .Values.xinferenceWorker.worker.ports | nindent 10 }}
-        resources: {{- toYaml .Values.xinferenceWorker.worker.resources | nindent 10 }}
+        resources: {{ include "charts.worker.resources" . | nindent 10 }}
 {{- if .Values.config.persistence.enabled }}
         volumeMounts:
           - mountPath: {{ .Values.config.persistence.mountPath }}

--- a/charts/xinference/values.yaml
+++ b/charts/xinference/values.yaml
@@ -86,6 +86,19 @@ xinferenceSupervisor:
         cpu: "1"
         memory: 4Gi
         nvidia.com/gpu: "1"
+    vgpu:
+      # enable HAMi vgpu
+      enabled: false
+      resources:
+        requests:
+          cpu: "1"
+          memory: 4Gi
+        limits:
+          cpu: "1"
+          memory: 4Gi
+          nvidia.com/gpu: "1"
+          nvidia.com/gpumem-percentage: 100
+          nvidia.com/gpucores: 100
 xinferenceWorker:
   strategy:
     type: Recreate
@@ -113,3 +126,16 @@ xinferenceWorker:
         cpu: "2"
         memory: 8Gi
         nvidia.com/gpu: "1"
+    vgpu:
+      # enable HAMi vgpu
+      enabled: false
+      resources:
+        requests:
+          cpu: "2"
+          memory: 8Gi
+        limits:
+          cpu: "2"
+          memory: 8Gi
+          nvidia.com/gpu: "1"
+          nvidia.com/gpumem-percentage: 100
+          nvidia.com/gpucores: 100


### PR DESCRIPTION
run xinference with hami vgpu in k8s.

This is my test:
```yaml
helm template xinference -n xinference ./charts/xinference --set xinferenceWorker.worker.vgpu.enabled=true --set xinferenceSupervisor.supervisor.vgpu.enabled=true
```

```yaml
# Source: xinference/templates/deployment-supervisor.yaml
apiVersion: v1
kind: Service
metadata:
  name: service-supervisor
  labels:
    helm.sh/chart: xinference-v0.14.0
    app.kubernetes.io/name: xinference
    app.kubernetes.io/instance: xinference
    app.kubernetes.io/version: "v0.14.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  selector:
    app: xinference-supervisor
    app.kubernetes.io/name: xinference
    app.kubernetes.io/instance: xinference
  ports:
  - name: service-supervisor-oscar
    port: 9999
    protocol: TCP
    targetPort: 9999
  - name: service-supervisor-web
    port: 9997
    protocol: TCP
    targetPort: 9997
---
# Source: xinference/templates/deployment-supervisor.yaml
apiVersion: v1
kind: Service
metadata:
  name: service-web
  labels:
    helm.sh/chart: xinference-v0.14.0
    app.kubernetes.io/name: xinference
    app.kubernetes.io/instance: xinference
    app.kubernetes.io/version: "v0.14.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: NodePort
  selector:
    app: xinference-supervisor
    app.kubernetes.io/name: xinference
    app.kubernetes.io/instance: xinference
  ports:
  - nodePort: 30003
    port: 9997
    protocol: TCP
    targetPort: 9997
---
# Source: xinference/templates/deployment-worker.yaml
apiVersion: v1
kind: Service
metadata:
  name: service-worker
  labels:
    helm.sh/chart: xinference-v0.14.0
    app.kubernetes.io/name: xinference
    app.kubernetes.io/instance: xinference
    app.kubernetes.io/version: "v0.14.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  selector:
    app: xinference-worker
    app.kubernetes.io/name: xinference
    app.kubernetes.io/instance: xinference
  ports:
  - port: 30001
    protocol: TCP
    targetPort: 30001
---
# Source: xinference/templates/deployment-supervisor.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: xinference-supervisor
  labels:
    helm.sh/chart: xinference-v0.14.0
    app.kubernetes.io/name: xinference
    app.kubernetes.io/instance: xinference
    app.kubernetes.io/version: "v0.14.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app: xinference-supervisor
      app.kubernetes.io/name: xinference
      app.kubernetes.io/instance: xinference
  template:
    metadata:
      labels:
        app: xinference-supervisor
        app.kubernetes.io/name: xinference
        app.kubernetes.io/instance: xinference
    spec:
      containers:
      - args:
        - --port
        - "9997"
        - --host
        - $(POD_IP)
        - --supervisor-port
        - "9999"
        - --log-level
        - debug
        command:
          - "xinference-supervisor"
        env:
        - name: POD_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        - name: XINFERENCE_POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        image: "xprobe/xinference:v0.14.0"
        name: supervisor
        ports:
          - containerPort: 9997
            name: web
          - containerPort: 9999
            name: oscar
        resources: 
          limits:
            cpu: "1"
            memory: 4Gi
            nvidia.com/gpu: "1"
            nvidia.com/gpucores: 100
            nvidia.com/gpumem-percentage: 100
          requests:
            cpu: "1"
            memory: 4Gi
---
# Source: xinference/templates/deployment-worker.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: xinference-worker
  labels:
    helm.sh/chart: xinference-v0.14.0
    app.kubernetes.io/name: xinference
    app.kubernetes.io/instance: xinference
    app.kubernetes.io/version: "v0.14.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app: xinference-worker
      app.kubernetes.io/name: xinference
      app.kubernetes.io/instance: xinference
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        app: xinference-worker
        app.kubernetes.io/name: xinference
        app.kubernetes.io/instance: xinference
    spec:
      initContainers:
      - name: check-supervisor
        image: "curlimages/curl:8.8.0"
        command:
        - sh
        - -c
        - until curl -v http://service-supervisor:9997/v1/address; do echo waiting for supervisor;
          sleep 1; done
      containers:
      - args:
        - -e
        - http://service-supervisor:9997
        - --host
        - $(POD_IP)
        - --worker-port
        - "30001"
        - --log-level
        - debug
        command:
        - xinference-worker
        env:
        - name: POD_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        - name: XINFERENCE_MODEL_SRC
          value: huggingface
        - name: XINFERENCE_POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        image: "xprobe/xinference:v0.14.0"
        name: worker
        ports:
          - containerPort: 30001
        resources: 
          limits:
            cpu: "2"
            memory: 8Gi
            nvidia.com/gpu: "1"
            nvidia.com/gpucores: 100
            nvidia.com/gpumem-percentage: 100
          requests:
            cpu: "2"
            memory: 8Gi
```